### PR TITLE
Fix typo in Custom Template Tags and Filters;

### DIFF
--- a/docs/custom-template-tags-and-filters.rst
+++ b/docs/custom-template-tags-and-filters.rst
@@ -42,7 +42,7 @@ Registering custom filters with arguments:
       }
 
       if let value = value as? Int {
-        return value * 2
+        return value * amount
       }
 
       return value


### PR DESCRIPTION
The issues fixes a typo in [Custom Template Tags and Filters](https://github.com/kylef/Stencil/blob/master/docs/custom-template-tags-and-filters.rst). The related issue is #127.